### PR TITLE
feat(plugins): migrate from matchit to matchup

### DIFF
--- a/lua/deltavim/plugins/matchup.lua
+++ b/lua/deltavim/plugins/matchup.lua
@@ -4,9 +4,9 @@ return {
   lazy = true,
   event = "VeryLazy",
   specs = {
-    "nvim-treesitter/nvim-treesitter",
-    matchup = {
-      enable = true,
+    "nvim-treesitter",
+    opts = {
+      matchup = { enable = true },
     },
   },
 }

--- a/lua/deltavim/plugins/matchup.lua
+++ b/lua/deltavim/plugins/matchup.lua
@@ -2,7 +2,7 @@
 return {
   "andymass/vim-matchup",
   lazy = true,
-  event = "VeryLazy",
+  event = "User AstroFile",
   specs = {
     "nvim-treesitter",
     opts = {

--- a/lua/deltavim/plugins/matchup.lua
+++ b/lua/deltavim/plugins/matchup.lua
@@ -9,4 +9,13 @@ return {
       matchup = { enable = true },
     },
   },
+  config = function(_, opts)
+    local ok, cmp = pcall(require, "cmp")
+    if ok then
+      -- https://github.com/hrsh7th/nvim-cmp/issues/1940#issuecomment-2241068952
+      cmp.event:on("menu_opened", function() vim.b.matchup_matchparen_enabled = false end)
+      cmp.event:on("menu_closed", function() vim.b.matchup_matchparen_enabled = true end)
+    end
+    require("match-up").setup(opts)
+  end,
 }

--- a/lua/deltavim/plugins/matchup.lua
+++ b/lua/deltavim/plugins/matchup.lua
@@ -1,0 +1,12 @@
+---@type LazyPluginSpec
+return {
+  "andymass/vim-matchup",
+  lazy = true,
+  event = "VeryLazy",
+  specs = {
+    "nvim-treesitter/nvim-treesitter",
+    matchup = {
+      enable = true,
+    },
+  },
+}


### PR DESCRIPTION
Hello o/

Consider this simple case:

https://github.com/user-attachments/assets/64129277-ce40-49e4-a33a-e2c511cd0b2e

Notice that pressing "%" to jump between opening and closing brackets is faulty with the default matchit built-in plugin. In particular, it chokes on the ["{"] case, treating it as an opening bracket.

To fix this, I propose using the [matchup](https://github.com/andymass/vim-matchup) plugin by default, which is a direct drop-in replacement.

https://github.com/user-attachments/assets/4e171fdb-174e-43ef-a7c3-c0321641c5c9

And now we can see that pressing "%" to jump between opening and closing brackets doesn't choke anymore on `["{"]` :)

Bonus: it also extends vim's % motion to language-specific words (if else endif ...)