### PR TITLE
fix(mini): dont clone modules unnecessarily

### DIFF
--- a/lua/deltavim/plugins/mini-bufremove.lua
+++ b/lua/deltavim/plugins/mini-bufremove.lua
@@ -1,2 +1,0 @@
----@type LazyPluginSpec
-return { "echasnovski/mini.bufremove", lazy = true }

--- a/lua/deltavim/plugins/mini/ai.lua
+++ b/lua/deltavim/plugins/mini/ai.lua
@@ -1,5 +1,6 @@
 return {
-  "echasnovski/mini.ai",
+  "mini.ai",
+  dev = true,
   event = "User AstroFile",
   dependencies = { "nvim-treesitter-textobjects" },
   opts = function()

--- a/lua/deltavim/plugins/mini/bufremove.lua
+++ b/lua/deltavim/plugins/mini/bufremove.lua
@@ -1,0 +1,6 @@
+---@type LazyPluginSpec
+return {
+  "mini.bufremove",
+  dev = true,
+  lazy = true,
+}

--- a/lua/deltavim/plugins/mini/comment.lua
+++ b/lua/deltavim/plugins/mini/comment.lua
@@ -1,6 +1,8 @@
 ---@type LazyPluginSpec
 return {
-  "echasnovski/mini.comment",
+  "mini.comment",
+  dev = true,
+  lazy = true,
   dependencies = { { "nvim-ts-context-commentstring", optional = true } },
   keys = function(self)
     local mappings = require("lazy.core.plugin").values(self, "opts", false).mappings or {}

--- a/lua/deltavim/plugins/mini/init.lua
+++ b/lua/deltavim/plugins/mini/init.lua
@@ -1,0 +1,12 @@
+---@type LazyPluginSpec[]
+local Spec = {
+  {
+    "echasnovski/mini.nvim",
+    lazy = false, -- PERF: don't stress the cache.
+  },
+  {
+    import = "deltavim.plugins.mini",
+  },
+}
+
+return not package.loaded["mini"] and Spec or {}

--- a/lua/deltavim/plugins/mini/pairs.lua
+++ b/lua/deltavim/plugins/mini/pairs.lua
@@ -1,6 +1,7 @@
 ---@type LazyPluginSpec
 return {
-  "echasnovski/mini.pairs",
+  "mini.pairs",
+  dev = true,
   event = "User AstroFile",
   opts = {
     modes = { insert = true, command = false, terminal = false },


### PR DESCRIPTION
Hello o/

Currently, we clone each mini module separately. This is redundant and it can be avoided by cloning mini.nvim once, which bundles its own modules ready to be (lazily) imported.

In short, there are two important parts to this PR:

1. **Grouping `mini` Modules**

For that, we group each `mini` module in a `mini/` subdirectory. This subdirectory will be merged into the final specification. At first, only `init.lua` is merged automatically, so we must ensure the rest of the modules are loaded along it. One clever trick to achieve this is to reimport `mini/init.lua`, but this time it will return an empty table as mini is already loaded which in turn will cause `lazy.nvim` to import the remaining lua files in said directory. This is done using `package.loaded` as a trap.

```lua
return not package.loaded["mini"] and Spec or {}
```

2. **Marking mini Specs with dev = true**

Finally, each mini spec must be marked with dev = true. This flag will tell lazy.nvim to perform a local lookup for each spec marked with it. From there, as you probably guessed already, lazy.nvim will find each mini module in the mini.nvim directory automatically.

##

The performance is roughly the same, but now we are saving precious resources for more demanding tasks: cloning, snapshots, and so on :)
