### PR TITLE
feat: allows direct bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 
 # User configurations
 /lua/pde
+/lua/pde.lua

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Lazy.nvim
+/lazy-lock.json
+
+# User configurations
+/lua/pde

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# TRY docker build -t deltavim:latest .
+#       && docker run --rm -it deltavim:latest
+# OR  docker build --target=base -t neovim:alpine-latest
+#       && docker run --rm -it -v $PWD:/root/.config/nvim neovim:alpine-latest
+
+FROM alpine:3.20 AS base
+
+RUN apk add --no-cache --update \
+    neovim~=0.10 \
+    alpine-sdk \
+    git \
+    ripgrep
+
+ENTRYPOINT ["nvim"]
+
+FROM base AS deltavim
+
+COPY . /root/.config/nvim

--- a/init.lua
+++ b/init.lua
@@ -1,0 +1,10 @@
+-- We can simply use `pcall(require, "pde")`, but that catches all errors and might lead to
+-- confusion since we only want to catch the "module not found" error.
+for _, searcher in ipairs(package.searchers) do
+  local loader = type(searcher) == "function" and searcher "pde"
+  if type(loader) == "function" then
+    -- Entrypoint of user's configuration
+    require "pde"
+    break
+  end
+end

--- a/lua/deltavim/utils/init.lua
+++ b/lua/deltavim/utils/init.lua
@@ -66,6 +66,10 @@ function M.make_mappings(dst, mappings)
         if loaded_mappings[key] == nil then -- lazy load mapping presets
           local module = vim.split(key, ".", { plain = true })[1]
           local existed, preset = pcall(require, "deltavim.mappings." .. module)
+          if not existed then
+            -- search in user's configuration directory
+            existed, preset = pcall(require, "pde.mappings." .. module)
+          end
           if existed then
             local cond = preset[1] and preset[1].cond
             if

--- a/plugin/lazy.lua
+++ b/plugin/lazy.lua
@@ -10,14 +10,15 @@ end
 
 local lazypath = vim.fs.joinpath(vim.fn.stdpath "data" --[[ @as string ]], "lazy", "lazy.nvim")
 if not vim.uv.fs_stat(lazypath) then
-  -- stylua: ignore
-  vim.system({
-    "git",
-    "clone",
-    "--filter=blob:none",
-    "https://github.com/folke/lazy.nvim",
-    lazypath,
-  }):wait()
+  vim
+    .system({
+      "git",
+      "clone",
+      "--filter=blob:none",
+      "https://github.com/folke/lazy.nvim",
+      lazypath,
+    })
+    :wait()
 end
 vim.opt.rtp:prepend(lazypath)
 

--- a/plugin/lazy.lua
+++ b/plugin/lazy.lua
@@ -1,0 +1,107 @@
+if package.loaded["lazy"] then
+  -- Note that lazy.nvim overrides Neovim's built-in loader, causing
+  -- pack/*/start/* to be sourced again. The overhead is minimal since we mark
+  -- the file as no-op after lazy.nvim loads (using package.loaded).
+  --
+  -- https://github.com/folke/lazy.nvim/issues/1180.
+  --
+  return
+end
+
+local lazypath = vim.fs.joinpath(vim.fn.stdpath "data" --[[ @as string ]], "lazy", "lazy.nvim")
+if not vim.uv.fs_stat(lazypath) then
+  -- stylua: ignore
+  vim.system({
+    "git",
+    "clone",
+    "--filter=blob:none",
+    "https://github.com/folke/lazy.nvim",
+    lazypath,
+  }):wait()
+end
+vim.opt.rtp:prepend(lazypath)
+
+local deltavim = require "deltavim"
+deltavim.setup {
+  mapleader = " ",
+  maplocalleader = "\\",
+  icons_enabled = true,
+  pin_plugins = vim.env.DELTA_PIN_PLUGINS == "1",
+}
+
+require("lazy").setup {
+  spec = {
+    {
+      "loichyan/DeltaVim",
+      priority = 1000,
+    },
+    { import = "deltavim.plugins" },
+    { import = "deltavim.presets.mappings" },
+  },
+
+  dev = {
+    path = vim.fn.stdpath "config",
+    patterns = { "loichyan" },
+    fallback = false,
+  },
+
+  -- These either have a direct replacement (e.g., matchit -> matchup) or
+  -- are just straight-up obsolete.
+  performance = {
+    rtp = {
+      disabled_plugins = {
+        "2html_plugin",
+        "bugreport",
+        "ftplugin",
+        "getscriptPlugin",
+        "getscript",
+        "gzip",
+        "health",
+        "logipat",
+        "matchit",
+        "matchparen",
+        "netrwFileHandlers",
+        "netrwPlugin",
+        "netrwSettings",
+        "netrw",
+        "nvim",
+        "optwin",
+        "rplugin",
+        "rrhelper",
+        "spellfile",
+        "spellfile_plugin",
+        "synmenu",
+        "syntax",
+        "tarPlugin",
+        "tar",
+        "tohtml",
+        "tutor",
+        "vimballPlugin",
+        "vimball",
+        "zipPlugin",
+        "zip",
+      },
+    },
+  },
+
+  -- https://github.com/folke/lazy.nvim/issues/1008
+  change_detection = {
+    enabled = false,
+  },
+
+  -- lazy can generate helptags from the headings in markdown readme files, so
+  -- :help works even for plugins that don't have vim docs. In practise though,
+  -- most README aren't made to be appropriate documentation (beyond the basic
+  -- setup), so this may confuse the average users.
+  readme = {
+    enabled = false,
+  },
+
+  -- Using a direct configuration often means that the user just wants an
+  -- out-of-the-box experience and pills show categories that are (IMO) more
+  -- geared toward plugin developers in general. Chances are that this is not
+  -- interesting for average users.
+  ui = {
+    pills = false,
+  },
+}


### PR DESCRIPTION
Hello o/

Perhaps a more controversial PR this time around. To cut it short, this PR intends to allow direct bootstrapping for DeltaVim. It’s quite trendy these days to redirect users toward a roundabout template that clones their distribution. I personally disagree with this trend, and instead say that we should make it much easier for average users to use it out of the box if they don’t care about manually configuring their setup.

For that, we introduce a bootstrapping mechanism as a global plugin (c.f. https://neovim.io/doc/user/usr_05.html#_global-plugins) which will clone lazy.nvim and use it to automatically import DeltaVim by treating it as a local plugin of its own:

> [!NOTE] 
> This will not impact custom configurations that use lazy.nvim with deltavim as a plugin (e.g., https://github.com/loichyan/nvim). For more details, see below.

```diff
  ├── lazy-lock.json
  ├── LICENSE
  ├── README.md
  ├── lua
  │   └── deltavim
  │       └── ...
+ └── plugin
+    └── lazy.lua
```

As you may know already, lazy.nvim overrides Neovim's built-in loader, causing `pack/*/start/*` to be sourced once more. Thankfully, the overhead is minimal since we mark the file as no-op after lazy.nvim loads with package.loaded [^1].

```lua
if package.loaded["lazy"] then
  return
end
```

Finally, there’s some opinionated configuration for lazy.nvim, mostly to make it even easier for average users to use DeltaVim-see the code for reference.

[^1]: This will also skip the global plugin for custom configuration that use lazy.nvim with deltavim as a plugin

Result:

![image](https://github.com/user-attachments/assets/8c65f05a-81a6-4f62-8369-0672b6b0179b)

![image](https://github.com/user-attachments/assets/5060236d-3390-4834-8173-095e918fb34f)

![image](https://github.com/user-attachments/assets/c2d22363-2812-43e9-85f1-26cb67325621)


