### PR TITLE
refactor: use lspkinds defined in mini.icons

### DIFF
--- a/lua/deltavim/lspkind.lua
+++ b/lua/deltavim/lspkind.lua
@@ -1,43 +1,10 @@
-return {
-  -- Credit: https://github.com/NvChad/ui/blob/1e0e198/lua/nvchad/icons/lspkind.lua
-  Array = "",
-  Boolean = "",
-  Calendar = "",
-  Class = "󰠱",
-  Codeium = "",
-  Color = "󰏘",
-  Constant = "󰏿",
-  Constructor = "",
-  Copilot = "",
-  Enum = "",
-  EnumMember = "",
-  Event = "",
-  Field = "󰜢",
-  File = "󰈚",
-  Folder = "󰉋",
-  Function = "󰆧",
-  Interface = "",
-  Keyword = "󰌋",
-  Method = "󰆧",
-  Module = "",
-  Namespace = "󰌗",
-  Null = "󰟢",
-  Number = "",
-  Object = "󰅩",
-  Operator = "󰆕",
-  Package = "",
-  Property = "󰜢",
-  Reference = "󰈇",
-  Snippet = "",
-  String = "󰉿",
-  Struct = "󰙅",
-  TabNine = "",
-  Table = "",
-  Tag = "",
-  Text = "󰉿",
-  TypeParameter = "󰊄",
-  Unit = "󰑭",
-  Value = "󰎠",
-  Variable = "󰀫",
-  Watch = "󰥔",
-}
+local lspkind, icons = {}, require "mini.icons"
+
+for _, kind in ipairs(vim.lsp.protocol.CompletionItemKind) do
+  lspkind[kind] = icons.get("lsp", kind)
+end
+for _, kind in ipairs(vim.lsp.protocol.SymbolKind) do
+  lspkind[kind] = icons.get("lsp", kind)
+end
+
+return lspkind

--- a/lua/deltavim/plugins/astroui_icons.lua
+++ b/lua/deltavim/plugins/astroui_icons.lua
@@ -3,7 +3,7 @@ return {
   "astroui",
   ---@param opts AstroUIOpts
   opts = function(_, opts)
-    opts.icons = require("deltavim.utils").merge({
+    opts.icons = {
       ActiveLSP = "",
       ActiveTS = "",
       ArrowLeft = "",
@@ -68,6 +68,6 @@ return {
       VimIcon = "",
       Window = "󱂬",
       WordFile = "󰈭",
-    } --[[@as AstroUIStatusOpts]], require "deltavim.lspkind")
+    }
   end,
 }

--- a/lua/deltavim/plugins/cmp.lua
+++ b/lua/deltavim/plugins/cmp.lua
@@ -64,7 +64,7 @@ return {
       end, { "i", "s" }),
     }
 
-    local icon = require("astroui").get_icon
+    local lspkind = require "deltavim.lspkind"
     ---@type cmp.ConfigSchema
     return {
       enabled = function()
@@ -81,7 +81,9 @@ return {
         expandable_indicator = true,
         fields = { "kind", "abbr" },
         format = function(_, item)
-          item.kind = " " .. icon(item.kind) .. " "
+          item.kind = " "
+            .. (lspkind[item.kind] or require("mini.icons").get("default", "lsp"))
+            .. " "
           return item
         end,
       },


### PR DESCRIPTION
Thanks to #16, we can now use lspkind icons from mini.icons instead of our defined ones.