### PR TITLE
fix(matchup): disable matchup_matchparen_offscreen

### DIFF
--- a/lua/deltavim/plugins/matchup.lua
+++ b/lua/deltavim/plugins/matchup.lua
@@ -9,6 +9,9 @@ return {
       matchup = { enable = true },
     },
   },
+  opts = {
+    matchparen_offscreen = {},
+  },
   config = function(_, opts)
     local ok, cmp = pcall(require, "cmp")
     if ok then
@@ -17,5 +20,11 @@ return {
       cmp.event:on("menu_closed", function() vim.b.matchup_matchparen_enabled = true end)
     end
     require("match-up").setup(opts)
+
+    -- Previously, if an 'open' or 'close' that would have been highlighted was
+    -- on a line positioned outside the current window, the match would be
+    -- shown in the statusline. As this overrides the statusline, it is
+    -- disabled by default.
+    vim.g.matchup_matchparen_offscreen = opts.matchparen_offscreen
   end,
 }


### PR DESCRIPTION
This would override the statusline in some situation 