### PR TITLE
fix(lspconfig): mark mason and mason-lspconfig as dependencies

### DIFF
--- a/lua/deltavim/plugins/lspconfig.lua
+++ b/lua/deltavim/plugins/lspconfig.lua
@@ -3,11 +3,15 @@ return {
   "neovim/nvim-lspconfig",
   event = "User AstroFile",
   cmd = { "LspInfo", "LspLog", "LspStart" },
-  dependencies = { { "neoconf.nvim", optional = true } },
+  dependencies = {
+    { "neoconf.nvim", optional = true },
+    { "williamboman/mason.nvim", config = true },
+    { "williamboman/mason-lspconfig.nvim", config = true }
+  },
   config = function(_, _)
     -- set border
     require("lspconfig.ui.windows").default_options.border =
-      require("deltavim").get_border "float_border"
+        require("deltavim").get_border "float_border"
     vim.tbl_map(require("astrolsp").lsp_setup, require("astrolsp").config.servers)
     require("astrocore").exec_buffer_autocmds("FileType", { group = "lspconfig" })
     require("astrocore").event "LspSetup"


### PR DESCRIPTION
This doesn’t handle automatic installation, but we can now install servers directly from Mason.

Fix #20. 

