### PR TITLE
docs: return explicit spec table for annotation

### DIFF
--- a/lua/deltavim/plugins/aerial.lua
+++ b/lua/deltavim/plugins/aerial.lua
@@ -1,5 +1,5 @@
 ---@type LazyPluginSpec
-return {
+local Spec = {
   "stevearc/aerial.nvim",
   event = "User AstroFile",
   opts = function()
@@ -36,3 +36,5 @@ return {
     return opts
   end,
 }
+
+return Spec

--- a/lua/deltavim/plugins/alpha.lua
+++ b/lua/deltavim/plugins/alpha.lua
@@ -1,5 +1,5 @@
 ---@type LazyPluginSpec
-return {
+local Spec = {
   "goolord/alpha-nvim",
   cmd = "Alpha",
 
@@ -171,3 +171,5 @@ return {
     })
   end,
 }
+
+return Spec

--- a/lua/deltavim/plugins/astrocore.lua
+++ b/lua/deltavim/plugins/astrocore.lua
@@ -1,5 +1,5 @@
 ---@type LazyPluginSpec
-return {
+local Spec = {
   "AstroNvim/astrocore",
   lazy = false,
   priority = 10000,
@@ -65,3 +65,5 @@ return {
     })
   end,
 }
+
+return Spec

--- a/lua/deltavim/plugins/astrocore_autocmds.lua
+++ b/lua/deltavim/plugins/astrocore_autocmds.lua
@@ -1,5 +1,5 @@
 ---@type LazyPluginSpec
-return {
+local Spec = {
   "astrocore",
   ---@param opts AstroCoreOpts
   opts = function(_, opts)
@@ -270,3 +270,5 @@ return {
     })
   end,
 }
+
+return Spec

--- a/lua/deltavim/plugins/astrocore_options.lua
+++ b/lua/deltavim/plugins/astrocore_options.lua
@@ -1,5 +1,5 @@
 ---@type LazyPluginSpec
-return {
+local Spec = {
   "astrocore",
   ---@param opts AstroCoreOpts
   opts = function(_, opts)
@@ -87,3 +87,5 @@ return {
     opts.options = { opt = opt, g = g }
   end,
 }
+
+return Spec

--- a/lua/deltavim/plugins/astrolsp.lua
+++ b/lua/deltavim/plugins/astrolsp.lua
@@ -1,5 +1,5 @@
 ---@type LazyPluginSpec
-return {
+local Spec = {
   "AstroNvim/astrolsp",
   lazy = true,
   ---@param opts AstroLSPOpts
@@ -43,3 +43,5 @@ return {
     })
   end,
 }
+
+return Spec

--- a/lua/deltavim/plugins/astrolsp_autocmds.lua
+++ b/lua/deltavim/plugins/astrolsp_autocmds.lua
@@ -1,5 +1,5 @@
 ---@type LazyPluginSpec
-return {
+local Spec = {
   "astrolsp",
   ---@param opts AstroLSPOpts
   opts = function(_, opts)
@@ -20,3 +20,5 @@ return {
     })
   end,
 }
+
+return Spec

--- a/lua/deltavim/plugins/astrotheme.lua
+++ b/lua/deltavim/plugins/astrotheme.lua
@@ -1,7 +1,9 @@
 ---@type LazyPluginSpec
-return {
+local Spec = {
   "AstroNvim/astrotheme",
   lazy = true,
   ---@type AstroThemeOpts
   opts = { plugins = { ["dashboard-nvim"] = true } },
 }
+
+return Spec

--- a/lua/deltavim/plugins/astroui.lua
+++ b/lua/deltavim/plugins/astroui.lua
@@ -1,5 +1,5 @@
 ---@type LazyPluginSpec
-return {
+local Spec = {
   "AstroNvim/astroui",
   lazy = true,
   ---@param opts AstroUIOpts
@@ -52,3 +52,5 @@ return {
     })
   end,
 }
+
+return Spec

--- a/lua/deltavim/plugins/astroui_highlights.lua
+++ b/lua/deltavim/plugins/astroui_highlights.lua
@@ -1,5 +1,5 @@
 ---@type LazyPluginSpec
-return {
+local Spec = {
   "astroui",
   ---@param opts AstroUIOpts
   opts = function(_, opts)
@@ -45,3 +45,5 @@ return {
     }
   end,
 }
+
+return Spec

--- a/lua/deltavim/plugins/astroui_icons.lua
+++ b/lua/deltavim/plugins/astroui_icons.lua
@@ -1,5 +1,5 @@
 ---@type LazyPluginSpec
-return {
+local Spec = {
   "astroui",
   ---@param opts AstroUIOpts
   opts = function(_, opts)
@@ -72,3 +72,5 @@ return {
     }
   end,
 }
+
+return Spec

--- a/lua/deltavim/plugins/astroui_status.lua
+++ b/lua/deltavim/plugins/astroui_status.lua
@@ -1,5 +1,5 @@
 ---@type LazyPluginSpec
-return {
+local Spec = {
   "astroui",
   ---@param opts AstroUIOpts
   opts = function(_, opts)
@@ -248,3 +248,5 @@ return {
     }
   end,
 }
+
+return Spec

--- a/lua/deltavim/plugins/better-escape.lua
+++ b/lua/deltavim/plugins/better-escape.lua
@@ -1,5 +1,5 @@
 ---@type LazyPluginSpec
-return {
+local Spec = {
   "max397574/better-escape.nvim",
   event = "VeryLazy",
   opts = {
@@ -10,3 +10,5 @@ return {
     },
   },
 }
+
+return Spec

--- a/lua/deltavim/plugins/catppuccin.lua
+++ b/lua/deltavim/plugins/catppuccin.lua
@@ -1,5 +1,5 @@
 ---@type LazyPluginSpec
-return {
+local Spec = {
   "catppuccin/nvim",
   name = "catppuccin",
   lazy = true,
@@ -58,3 +58,5 @@ return {
     end,
   },
 }
+
+return Spec

--- a/lua/deltavim/plugins/cmp-nvim-lsp.lua
+++ b/lua/deltavim/plugins/cmp-nvim-lsp.lua
@@ -1,5 +1,5 @@
 ---@type LazyPluginSpec
-return {
+local Spec = {
   "hrsh7th/cmp-nvim-lsp",
   lazy = true,
   specs = {
@@ -30,3 +30,5 @@ return {
     },
   },
 }
+
+return Spec

--- a/lua/deltavim/plugins/cmp.lua
+++ b/lua/deltavim/plugins/cmp.lua
@@ -1,5 +1,5 @@
 ---@type LazyPluginSpec
-return {
+local Spec = {
   "hrsh7th/nvim-cmp",
   event = "InsertEnter",
 
@@ -120,3 +120,5 @@ return {
     require("cmp").setup(opts)
   end,
 }
+
+return Spec

--- a/lua/deltavim/plugins/conform.lua
+++ b/lua/deltavim/plugins/conform.lua
@@ -1,6 +1,6 @@
 -- Credit: https://github.com/AstroNvim/astrocommunity/blob/c547c9e/lua/astrocommunity/editing-support/conform-nvim/init.lua
 ---@type LazyPluginSpec
-return {
+local Spec = {
   "stevearc/conform.nvim",
   event = "User AstroFile",
   cmd = { "Format", "ConformInfo" },
@@ -37,3 +37,5 @@ return {
     },
   },
 }
+
+return Spec

--- a/lua/deltavim/plugins/dressing.lua
+++ b/lua/deltavim/plugins/dressing.lua
@@ -1,5 +1,5 @@
 ---@type LazyPluginSpec
-return {
+local Spec = {
   "stevearc/dressing.nvim",
   lazy = true,
   init = function()
@@ -12,3 +12,5 @@ return {
     }
   end,
 }
+
+return Spec

--- a/lua/deltavim/plugins/gitsigns.lua
+++ b/lua/deltavim/plugins/gitsigns.lua
@@ -1,6 +1,6 @@
 ---@diagnostic disable: missing-fields
 ---@type LazyPluginSpec
-return {
+local Spec = {
   "lewis6991/gitsigns.nvim",
   enabled = vim.fn.executable "git" == 1,
   event = "User AstroFile",
@@ -23,3 +23,5 @@ return {
     }
   end,
 }
+
+return Spec

--- a/lua/deltavim/plugins/guess-indent.lua
+++ b/lua/deltavim/plugins/guess-indent.lua
@@ -1,5 +1,5 @@
 ---@type LazyPluginSpec
-return {
+local Spec = {
   "NMAC427/guess-indent.nvim",
   cmd = "GuessIndent",
   specs = {
@@ -35,3 +35,5 @@ return {
   },
   opts = { auto_cmd = false },
 }
+
+return Spec

--- a/lua/deltavim/plugins/heirline.lua
+++ b/lua/deltavim/plugins/heirline.lua
@@ -1,5 +1,5 @@
 ---@type LazyPluginSpec
-return {
+local Spec = {
   "rebelot/heirline.nvim",
   event = "BufEnter",
 
@@ -241,3 +241,5 @@ return {
     })
   end,
 }
+
+return Spec

--- a/lua/deltavim/plugins/indent-blankline.lua
+++ b/lua/deltavim/plugins/indent-blankline.lua
@@ -1,5 +1,5 @@
 ---@type LazyPluginSpec
-return {
+local Spec = {
   "lukas-reineke/indent-blankline.nvim",
   main = "ibl",
   event = "User AstroFile",
@@ -44,3 +44,5 @@ return {
     },
   },
 }
+
+return Spec

--- a/lua/deltavim/plugins/init.lua
+++ b/lua/deltavim/plugins/init.lua
@@ -5,7 +5,7 @@ local deltavim = require "deltavim"
 deltavim.init()
 
 ---@type LazySpec
-return {
+local Spec = {
   { "folke/lazy.nvim", dir = vim.env.LAZY },
   { "loichyan/DeltaVim", lazy = false, priority = 10000 },
 
@@ -23,3 +23,5 @@ return {
 
   { import = "deltavim.snapshot", cond = deltavim.config.pin_plugins },
 }
+
+return Spec

--- a/lua/deltavim/plugins/lazydev.lua
+++ b/lua/deltavim/plugins/lazydev.lua
@@ -1,6 +1,6 @@
 -- Credit: https://github.com/AstroNvim/AstroNvim/blob/0126d447633a/lua/astronvim/plugins/lazydev.lua#L1
 
-return {
+local Spec = {
   "folke/lazydev.nvim",
   ft = "lua",
   cmd = "LazyDev",
@@ -34,3 +34,5 @@ return {
     },
   },
 }
+
+return Spec

--- a/lua/deltavim/plugins/lint.lua
+++ b/lua/deltavim/plugins/lint.lua
@@ -2,7 +2,7 @@
 --   https://github.com/AstroNvim/astrocommunity/blob/c547c9e/lua/astrocommunity/lsp/nvim-lint/init.lua
 --   https://github.com/LazyVim/LazyVim/blob/07923f3/lua/lazyvim/plugins/linting.lua
 ---@type LazyPluginSpec
-return {
+local Spec = {
   "mfussenegger/nvim-lint",
   event = "User AstroFile",
   opts = {
@@ -37,3 +37,5 @@ return {
     })
   end,
 }
+
+return Spec

--- a/lua/deltavim/plugins/lspconfig.lua
+++ b/lua/deltavim/plugins/lspconfig.lua
@@ -1,5 +1,5 @@
 ---@type LazyPluginSpec
-return {
+local Spec = {
   "neovim/nvim-lspconfig",
   event = "User AstroFile",
   cmd = { "LspInfo", "LspLog", "LspStart" },
@@ -13,3 +13,5 @@ return {
     require("astrocore").event "LspSetup"
   end,
 }
+
+return Spec

--- a/lua/deltavim/plugins/luasnip.lua
+++ b/lua/deltavim/plugins/luasnip.lua
@@ -1,5 +1,5 @@
 ---@type LazyPluginSpec
-return {
+local Spec = {
   "L3MON4D3/LuaSnip",
   lazy = true,
   dependencies = { { "rafamadriz/friendly-snippets", lazy = true } },
@@ -48,3 +48,5 @@ return {
     require("luasnip.loaders.from_lua").lazy_load()
   end,
 }
+
+return Spec

--- a/lua/deltavim/plugins/matchup.lua
+++ b/lua/deltavim/plugins/matchup.lua
@@ -1,5 +1,5 @@
 ---@type LazyPluginSpec
-return {
+local Spec = {
   "andymass/vim-matchup",
   lazy = true,
   event = "User AstroFile",
@@ -28,3 +28,5 @@ return {
     vim.g.matchup_matchparen_offscreen = opts.matchparen_offscreen
   end,
 }
+
+return Spec

--- a/lua/deltavim/plugins/mini-ai.lua
+++ b/lua/deltavim/plugins/mini-ai.lua
@@ -1,4 +1,4 @@
-return {
+local Spec = {
   "echasnovski/mini.ai",
   event = "User AstroFile",
   dependencies = { "nvim-treesitter-textobjects" },
@@ -43,3 +43,5 @@ return {
     end
   end,
 }
+
+return Spec

--- a/lua/deltavim/plugins/mini-bufremove.lua
+++ b/lua/deltavim/plugins/mini-bufremove.lua
@@ -1,2 +1,7 @@
 ---@type LazyPluginSpec
-return { "echasnovski/mini.bufremove", lazy = true }
+local Spec = {
+  "echasnovski/mini.bufremove",
+  lazy = true
+}
+
+return Spec

--- a/lua/deltavim/plugins/mini-comment.lua
+++ b/lua/deltavim/plugins/mini-comment.lua
@@ -1,5 +1,5 @@
 ---@type LazyPluginSpec
-return {
+local Spec = {
   "echasnovski/mini.comment",
   dependencies = { { "nvim-ts-context-commentstring", optional = true } },
   keys = function(self)
@@ -28,3 +28,5 @@ return {
     }
   end,
 }
+
+return Spec

--- a/lua/deltavim/plugins/mini-hipatterns.lua
+++ b/lua/deltavim/plugins/mini-hipatterns.lua
@@ -1,7 +1,7 @@
 ---@module "mini.hipatterns"
 
 ---@type LazyPluginSpec
-return {
+local Spec = {
   "echasnovski/mini.hipatterns",
   event = "VeryLazy",
   opts = function()
@@ -13,3 +13,5 @@ return {
     }
   end
 }
+
+return Spec

--- a/lua/deltavim/plugins/mini-icons.lua
+++ b/lua/deltavim/plugins/mini-icons.lua
@@ -1,5 +1,5 @@
 ---@type LazyPluginSpec
-return {
+local Spec = {
   "echasnovski/mini.icons",
   event = "VeryLazy",
   config = function(_, opts)
@@ -8,3 +8,5 @@ return {
     icons.mock_nvim_web_devicons()
   end,
 }
+
+return Spec

--- a/lua/deltavim/plugins/mini-pairs.lua
+++ b/lua/deltavim/plugins/mini-pairs.lua
@@ -1,5 +1,5 @@
 ---@type LazyPluginSpec
-return {
+local Spec = {
   "echasnovski/mini.pairs",
   event = "User AstroFile",
   opts = {
@@ -43,3 +43,5 @@ return {
     end
   end,
 }
+
+return Spec

--- a/lua/deltavim/plugins/neo-tree.lua
+++ b/lua/deltavim/plugins/neo-tree.lua
@@ -1,5 +1,5 @@
 ---@type LazyPluginSpec
-return {
+local Spec = {
   "nvim-neo-tree/neo-tree.nvim",
   cmd = "Neotree",
 
@@ -179,3 +179,5 @@ return {
     }
   end,
 }
+
+return Spec

--- a/lua/deltavim/plugins/neoconf.lua
+++ b/lua/deltavim/plugins/neoconf.lua
@@ -1,2 +1,6 @@
 ---@type LazyPluginSpec
-return { "folke/neoconf.nvim", lazy = true, opts = {} }
+local Spec = {
+  "folke/neoconf.nvim", lazy = true, opts = {}
+}
+
+return Spec

--- a/lua/deltavim/plugins/notify.lua
+++ b/lua/deltavim/plugins/notify.lua
@@ -1,5 +1,5 @@
 ---@type LazyPluginSpec
-return {
+local Spec = {
   "rcarriga/nvim-notify",
   lazy = true,
   init = function() require("astrocore").load_plugin_with_func("nvim-notify", vim, "notify") end,
@@ -40,3 +40,5 @@ return {
     require("deltavim.notify").setup(notify)
   end,
 }
+
+return Spec

--- a/lua/deltavim/plugins/plenary.lua
+++ b/lua/deltavim/plugins/plenary.lua
@@ -1,2 +1,7 @@
 ---@type LazyPluginSpec
-return { "nvim-lua/plenary.nvim", lazy = true }
+local Spec = {
+  "nvim-lua/plenary.nvim", lazy = true
+}
+
+return Spec
+

--- a/lua/deltavim/plugins/resession.lua
+++ b/lua/deltavim/plugins/resession.lua
@@ -1,5 +1,5 @@
 ---@type LazyPluginSpec
-return {
+local Spec = {
   "stevearc/resession.nvim",
   lazy = true,
   specs = {
@@ -36,3 +36,5 @@ return {
     extensions = { astrocore = { enable_in_tab = true } },
   },
 }
+
+return Spec

--- a/lua/deltavim/plugins/smart-splits.lua
+++ b/lua/deltavim/plugins/smart-splits.lua
@@ -1,5 +1,5 @@
 ---@type LazyPluginSpec
-return {
+local Spec = {
   "mrjones2014/smart-splits.nvim",
   event = "VeryLazy",
   opts = {
@@ -8,3 +8,5 @@ return {
     ignored_buftypes = { "nofile" },
   },
 }
+
+return Spec

--- a/lua/deltavim/plugins/telescope-fzf-native.lua
+++ b/lua/deltavim/plugins/telescope-fzf-native.lua
@@ -1,6 +1,9 @@
-return {
+---@type LazyPluginSpec
+local Spec = {
   "nvim-telescope/telescope-fzf-native.nvim",
   lazy = true,
   enabled = vim.fn.executable "make" == 1,
   build = "make",
 }
+
+return Spec

--- a/lua/deltavim/plugins/telescope.lua
+++ b/lua/deltavim/plugins/telescope.lua
@@ -1,5 +1,5 @@
 ---@type LazyPluginSpec
-return {
+local Spec = {
   "nvim-telescope/telescope.nvim",
   cmd = "Telescope",
   dependencies = { { "telescope-fzf-native.nvim", optional = true } },
@@ -49,3 +49,5 @@ return {
     if is_available "telescope-fzf-native.nvim" then telescope.load_extension "fzf" end
   end,
 }
+
+return Spec

--- a/lua/deltavim/plugins/todo-comments.lua
+++ b/lua/deltavim/plugins/todo-comments.lua
@@ -1,7 +1,9 @@
 ---@type LazyPluginSpec
-return {
+local Spec = {
   "folke/todo-comments.nvim",
   event = "User AstroFile",
   cmd = { "TodoTrouble", "TodoTelescope", "TodoLocList", "TodoQuickFix" },
   opts = { highlight = { multiline = true } },
 }
+
+return Spec

--- a/lua/deltavim/plugins/treesitter-textobjects.lua
+++ b/lua/deltavim/plugins/treesitter-textobjects.lua
@@ -1,5 +1,5 @@
 ---@type LazyPluginSpec
-return {
+local Spec = {
   "nvim-treesitter/nvim-treesitter-textobjects",
   event = "User AstroFile",
   dependencies = {
@@ -49,3 +49,5 @@ return {
     },
   },
 }
+
+return Spec

--- a/lua/deltavim/plugins/treesitter.lua
+++ b/lua/deltavim/plugins/treesitter.lua
@@ -1,5 +1,5 @@
 ---@type LazyPluginSpec
-return {
+local Spec = {
   "nvim-treesitter/nvim-treesitter",
   event = "User AstroFile",
   cmd = {
@@ -52,3 +52,5 @@ return {
   opts_extend = { "ensure_installed" },
   config = function(_, opts) require("nvim-treesitter.configs").setup(opts) end,
 }
+
+return Spec

--- a/lua/deltavim/plugins/ts-autotag.lua
+++ b/lua/deltavim/plugins/ts-autotag.lua
@@ -1,5 +1,5 @@
 ---@type LazyPluginSpec
-return {
+local Spec = {
   "windwp/nvim-ts-autotag",
   event = "User AstroFile",
   dependencies = { "nvim-treesitter" },
@@ -14,3 +14,5 @@ return {
       })
   end,
 }
+
+return Spec

--- a/lua/deltavim/plugins/ts-context-commentstring.lua
+++ b/lua/deltavim/plugins/ts-context-commentstring.lua
@@ -1,6 +1,8 @@
 ---@type LazyPluginSpec
-return {
+local Spec = {
   "JoosepAlviste/nvim-ts-context-commentstring",
   lazy = true,
   opts = { enable_autocmd = false },
 }
+
+return Spec

--- a/lua/deltavim/plugins/ufo.lua
+++ b/lua/deltavim/plugins/ufo.lua
@@ -1,5 +1,5 @@
 ---@type LazyPluginSpec
-return {
+local Spec = {
   "kevinhwang91/nvim-ufo",
   event = { "User AstroFile", "InsertEnter" },
   dependencies = { { "kevinhwang91/promise-async", lazy = true } },
@@ -60,3 +60,5 @@ return {
     map("n", "zp", ufo.peekFoldedLinesUnderCursor)
   end,
 }
+
+return Spec

--- a/lua/deltavim/plugins/vim-illuminate.lua
+++ b/lua/deltavim/plugins/vim-illuminate.lua
@@ -1,5 +1,5 @@
 ---@type LazyPluginSpec
-return {
+local Spec = {
   "RRethy/vim-illuminate",
   event = "User AstroFile",
   opts = function()
@@ -15,3 +15,5 @@ return {
   end,
   config = function(_, opts) require("illuminate").configure(opts) end,
 }
+
+return Spec

--- a/lua/deltavim/plugins/which-key.lua
+++ b/lua/deltavim/plugins/which-key.lua
@@ -1,5 +1,5 @@
 ---@type LazyPluginSpec
-return {
+local Spec = {
   "folke/which-key.nvim",
   event = "VeryLazy",
   opts = function()
@@ -14,3 +14,5 @@ return {
     }
   end,
 }
+
+return Spec

--- a/lua/deltavim/plugins/window-picker.lua
+++ b/lua/deltavim/plugins/window-picker.lua
@@ -1,5 +1,5 @@
 ---@type LazyPluginSpec
-return {
+local Spec = {
   "s1n7ax/nvim-window-picker",
   lazy = true,
   opts = {
@@ -8,3 +8,5 @@ return {
     },
   },
 }
+
+return Spec


### PR DESCRIPTION
Return a specification table explicitly for every plugin so that annotations can properly propagate, e.g., with LSP hover.

![Screenshot from 2024-09-11 10-03-59](https://github.com/user-attachments/assets/53734d49-d669-42ce-9dbb-162618b77e84)
