### PR TITLE
fix(plugins): use appropriate module name

### DIFF
--- a/lua/deltavim/plugins/aerial.lua
+++ b/lua/deltavim/plugins/aerial.lua
@@ -1,4 +1,4 @@
----@module "aerial"
+---@module "aerial.nvim"
 
 ---@type LazyPluginSpec
 local Spec = {

--- a/lua/deltavim/plugins/alpha.lua
+++ b/lua/deltavim/plugins/alpha.lua
@@ -1,4 +1,4 @@
----@module "alpha"
+---@module "alpha-nvim"
 
 ---@type LazyPluginSpec
 local Spec = {
@@ -33,11 +33,11 @@ local Spec = {
                 local keys = { "showtabline", "laststatus", "cmdheight" }
 
                 if
-                  not before
-                  and (
-                    (ev.event == "User" and ev.file == "AlphaReady")
-                    or (ev.event == "BufWinEnter" and vim.bo[ev.buf].filetype == "alpha")
-                  )
+                    not before
+                    and (
+                      (ev.event == "User" and ev.file == "AlphaReady")
+                      or (ev.event == "BufWinEnter" and vim.bo[ev.buf].filetype == "alpha")
+                    )
                 then
                   before = {}
                   for _, k in ipairs(keys) do
@@ -46,9 +46,9 @@ local Spec = {
                   end
                   vim.g.before_alpha = before
                 elseif
-                  before
-                  and ev.event == "BufWinEnter"
-                  and vim.bo[ev.buf].buftype ~= "nofile"
+                    before
+                    and ev.event == "BufWinEnter"
+                    and vim.bo[ev.buf].buftype ~= "nofile"
                 then
                   for _, k in ipairs(keys) do
                     vim.opt[k] = before[k]
@@ -161,12 +161,12 @@ local Spec = {
         local ms = math.floor(stats.startuptime * 100 + 0.5) / 100
         opts.section.footer.val = {
           "Neovim loaded "
-            .. stats.loaded
-            .. "/"
-            .. stats.count
-            .. " plugins  in "
-            .. ms
-            .. "ms",
+          .. stats.loaded
+          .. "/"
+          .. stats.count
+          .. " plugins  in "
+          .. ms
+          .. "ms",
         }
         pcall(vim.cmd.AlphaRedraw)
       end,

--- a/lua/deltavim/plugins/astrolsp.lua
+++ b/lua/deltavim/plugins/astrolsp.lua
@@ -1,4 +1,4 @@
----@module "astrocore"
+---@module "astrolsp"
 
 ---@type LazyPluginSpec
 local Spec = {

--- a/lua/deltavim/plugins/astrotheme.lua
+++ b/lua/deltavim/plugins/astrotheme.lua
@@ -1,4 +1,4 @@
----@module "astrolsp"
+---@module "astrotheme"
 
 ---@type LazyPluginSpec
 local Spec = {

--- a/lua/deltavim/plugins/better-escape.lua
+++ b/lua/deltavim/plugins/better-escape.lua
@@ -1,4 +1,4 @@
----@module "better-escape"
+---@module "better-escape.nvim"
 
 ---@type LazyPluginSpec
 local Spec = {

--- a/lua/deltavim/plugins/cmp-nvim-lsp.lua
+++ b/lua/deltavim/plugins/cmp-nvim-lsp.lua
@@ -1,4 +1,4 @@
----@module "cmp"
+---@module "cmp-nvim-lsp"
 
 ---@type LazyPluginSpec
 local Spec = {

--- a/lua/deltavim/plugins/cmp.lua
+++ b/lua/deltavim/plugins/cmp.lua
@@ -1,4 +1,4 @@
----@module "cmp"
+---@module "nvim-cmp"
 
 ---@type LazyPluginSpec
 local Spec = {
@@ -7,8 +7,8 @@ local Spec = {
 
   dependencies = {
     { "hrsh7th/cmp-buffer", lazy = true },
-    { "hrsh7th/cmp-path", lazy = true },
-    { "cmp-nvim-lsp", optional = true },
+    { "hrsh7th/cmp-path",   lazy = true },
+    { "cmp-nvim-lsp",       optional = true },
   },
 
   opts = function()
@@ -44,9 +44,9 @@ local Spec = {
 
       ["<Tab>"] = cmapping(function(fallback)
         if
-          vim.api.nvim_get_mode() ~= "c"
-          and vim.snippet
-          and vim.snippet.active { direction = 1 }
+            vim.api.nvim_get_mode() ~= "c"
+            and vim.snippet
+            and vim.snippet.active { direction = 1 }
         then
           vim.schedule(function() vim.snippet.jump(1) end)
         else
@@ -55,9 +55,9 @@ local Spec = {
       end, { "i", "s" }),
       ["<S-Tab>"] = cmapping(function(fallback)
         if
-          vim.api.nvim_get_mode() ~= "c"
-          and vim.snippet
-          and vim.snippet.active { direction = -1 }
+            vim.api.nvim_get_mode() ~= "c"
+            and vim.snippet
+            and vim.snippet.active { direction = -1 }
         then
           vim.schedule(function() vim.snippet.jump(-1) end)
         else
@@ -84,8 +84,8 @@ local Spec = {
         fields = { "kind", "abbr" },
         format = function(_, item)
           item.kind = " "
-            .. (lspkind[item.kind] or require("mini.icons").get("default", "lsp"))
-            .. " "
+              .. (lspkind[item.kind] or require("mini.icons").get("default", "lsp"))
+              .. " "
           return item
         end,
       },
@@ -107,9 +107,9 @@ local Spec = {
         },
       },
       sources = {
-        { name = "buffer", priority = 500, group_index = 2 },
+        { name = "buffer",   priority = 500, group_index = 2 },
         { name = "nvim_lsp", priority = 1000 },
-        { name = "path", priority = 250 },
+        { name = "path",     priority = 250 },
       },
       mapping = mapping,
     }

--- a/lua/deltavim/plugins/dressing.lua
+++ b/lua/deltavim/plugins/dressing.lua
@@ -1,4 +1,4 @@
----@module "dressing"
+---@module "dressing.nvim"
 
 ---@type LazyPluginSpec
 local Spec = {

--- a/lua/deltavim/plugins/gitsigns.lua
+++ b/lua/deltavim/plugins/gitsigns.lua
@@ -1,4 +1,4 @@
----@module "gitsigns"
+---@module "gitsigns.nvim"
 
 ---@type LazyPluginSpec
 local Spec = {

--- a/lua/deltavim/plugins/guess-indent.lua
+++ b/lua/deltavim/plugins/guess-indent.lua
@@ -1,4 +1,4 @@
----@module "guess-indent"
+---@module "guess-indent.nvim"
 
 ---@type LazyPluginSpec
 local Spec = {

--- a/lua/deltavim/plugins/heirline.lua
+++ b/lua/deltavim/plugins/heirline.lua
@@ -1,4 +1,4 @@
----@module "herline"
+---@module "herline.nvim"
 
 ---@type LazyPluginSpec
 local Spec = {
@@ -22,7 +22,7 @@ local Spec = {
         colors = require("astroui").config.status.setup_colors(),
         disable_winbar_cb = function(args)
           return not require("astrocore.buffer").is_valid(args.buf)
-            or condition.buffer_matches({ buftype = { "terminal", "nofile" } }, args.buf)
+              or condition.buffer_matches({ buftype = { "terminal", "nofile" } }, args.buf)
         end,
       },
 

--- a/lua/deltavim/plugins/indent-blankline.lua
+++ b/lua/deltavim/plugins/indent-blankline.lua
@@ -1,4 +1,4 @@
----@module "indent-blankline"
+---@module "indent-blankline.nvim"
 
 ---@type LazyPluginSpec
 local Spec = {

--- a/lua/deltavim/plugins/lazydev.lua
+++ b/lua/deltavim/plugins/lazydev.lua
@@ -1,4 +1,4 @@
----@module "lazydev"
+---@module "lazydev.nvim"
 
 local Spec = {
   "folke/lazydev.nvim",
@@ -6,11 +6,11 @@ local Spec = {
   cmd = "LazyDev",
   opts = function(_, opts)
     opts.library = {
-      { path = "astrocore", words = { "AstroCore" } },
-      { path = "astrolsp", words = { "AstroLSP" } },
-      { path = "astrotheme", words = { "AstroTheme" } },
-      { path = "astroui", words = { "AstroUI" } },
-      { path = "lazy.nvim", words = { "Lazy" } },
+      { path = "astrocore",          words = { "AstroCore" } },
+      { path = "astrolsp",           words = { "AstroLSP" } },
+      { path = "astrotheme",         words = { "AstroTheme" } },
+      { path = "astroui",            words = { "AstroUI" } },
+      { path = "lazy.nvim",          words = { "Lazy" } },
       { path = "luvit-meta/library", words = { "vim%.uv" } },
     }
     if vim.fn.has "nvim-0.10" ~= 1 then

--- a/lua/deltavim/plugins/lint.lua
+++ b/lua/deltavim/plugins/lint.lua
@@ -1,4 +1,4 @@
----@module "lint"
+---@module "nvim-lint"
 
 ---@type LazyPluginSpec
 local Spec = {
@@ -21,7 +21,7 @@ local Spec = {
       local base = lint.linters[name]
       lint.linters[name] = (type(linter) == "table" and type(base) == "table")
           and vim.tbl_deep_extend("force", base, linter)
-        or linter
+          or linter
     end
 
     lint.linters_by_ft = opts.linters_by_ft

--- a/lua/deltavim/plugins/lspconfig.lua
+++ b/lua/deltavim/plugins/lspconfig.lua
@@ -1,11 +1,13 @@
+---@module "nvim-lspconfig"
+
 ---@type LazyPluginSpec
 local Spec = {
   "neovim/nvim-lspconfig",
   event = "User AstroFile",
   cmd = { "LspInfo", "LspLog", "LspStart" },
   dependencies = {
-    { "neoconf.nvim", optional = true },
-    { "williamboman/mason.nvim", config = true },
+    { "neoconf.nvim",                      optional = true },
+    { "williamboman/mason.nvim",           config = true },
     { "williamboman/mason-lspconfig.nvim", config = true }
   },
   config = function(_, _)

--- a/lua/deltavim/plugins/luasnip.lua
+++ b/lua/deltavim/plugins/luasnip.lua
@@ -2,7 +2,7 @@
 
 ---@type LazyPluginSpec
 local Spec = {
-  "L3MON4D3/LuaSnip",
+  "l3mon4d3/luasnip",
   lazy = true,
   dependencies = { { "rafamadriz/friendly-snippets", lazy = true } },
   specs = {

--- a/lua/deltavim/plugins/neo-tree.lua
+++ b/lua/deltavim/plugins/neo-tree.lua
@@ -1,4 +1,4 @@
----@module "neo-tree"
+---@module "neo-tree.nvim"
 
 ---@type LazyPluginSpec
 local Spec = {
@@ -18,8 +18,8 @@ local Spec = {
               desc = "Open Explorer on startup with directory",
               callback = function()
                 if
-                  package.loaded["neo-tree"]
-                  or not require("astrocore").is_available "neo-tree.nvim"
+                    package.loaded["neo-tree"]
+                    or not require("astrocore").is_available "neo-tree.nvim"
                 then
                   return true
                 end

--- a/lua/deltavim/plugins/neoconf.lua
+++ b/lua/deltavim/plugins/neoconf.lua
@@ -1,4 +1,4 @@
----@module "neoconf"
+---@module "neoconf.nvim"
 
 ---@type LazyPluginSpec
 local Spec = {

--- a/lua/deltavim/plugins/notify.lua
+++ b/lua/deltavim/plugins/notify.lua
@@ -1,4 +1,4 @@
----@module "notify"
+---@module "nvim-notify"
 
 ---@type LazyPluginSpec
 local Spec = {

--- a/lua/deltavim/plugins/plenary.lua
+++ b/lua/deltavim/plugins/plenary.lua
@@ -1,4 +1,4 @@
----@module "plenary"
+---@module "plenary.nvim"
 
 ---@type LazyPluginSpec
 local Spec = {
@@ -6,4 +6,3 @@ local Spec = {
 }
 
 return Spec
-

--- a/lua/deltavim/plugins/resession.lua
+++ b/lua/deltavim/plugins/resession.lua
@@ -1,4 +1,4 @@
----@module "resession"
+---@module "resession.nvim"
 
 ---@type LazyPluginSpec
 local Spec = {

--- a/lua/deltavim/plugins/smart-splits.lua
+++ b/lua/deltavim/plugins/smart-splits.lua
@@ -1,4 +1,4 @@
----@module "smart-splits"
+---@module "smart-splits.nvim"
 
 ---@type LazyPluginSpec
 local Spec = {

--- a/lua/deltavim/plugins/telescope-fzf-native.lua
+++ b/lua/deltavim/plugins/telescope-fzf-native.lua
@@ -1,4 +1,4 @@
----@module "telescope-fzf-native"
+---@module "telescope-fzf-native.nvim"
 
 ---@type LazyPluginSpec
 local Spec = {

--- a/lua/deltavim/plugins/telescope.lua
+++ b/lua/deltavim/plugins/telescope.lua
@@ -1,4 +1,4 @@
----@module "telescope"
+---@module "telescope.nvim"
 
 ---@type LazyPluginSpec
 local Spec = {

--- a/lua/deltavim/plugins/todo-comments.lua
+++ b/lua/deltavim/plugins/todo-comments.lua
@@ -1,4 +1,4 @@
----@module "todo-comments"
+---@module "todo-comments.nvim"
 
 ---@type LazyPluginSpec
 local Spec = {

--- a/lua/deltavim/plugins/treesitter-textobjects.lua
+++ b/lua/deltavim/plugins/treesitter-textobjects.lua
@@ -1,4 +1,4 @@
----@module "treesitter-textobjects"
+---@module "nvim-treesitter-textobjects"
 
 ---@type LazyPluginSpec
 local Spec = {

--- a/lua/deltavim/plugins/treesitter.lua
+++ b/lua/deltavim/plugins/treesitter.lua
@@ -1,4 +1,4 @@
----@module "treesitter"
+---@module "nvim-treesitter"
 
 ---@type LazyPluginSpec
 local Spec = {

--- a/lua/deltavim/plugins/which-key.lua
+++ b/lua/deltavim/plugins/which-key.lua
@@ -1,4 +1,4 @@
----@module "which-key"
+---@module "which-key.nvim"
 
 ---@type LazyPluginSpec
 local Spec = {


### PR DESCRIPTION
Fix the name for some plugins' `---@module` annotations. In particular, we have to use the installation directory name (i.e., foobar.nvim for lazy/foobar.nvim) and not the "module" name from lua/ (i.e., lazy/foobar.nvim/lua/foobar).